### PR TITLE
Merge latest perturbation code with Id 1.2

### DIFF
--- a/libid/engine/PertEngine.cpp
+++ b/libid/engine/PertEngine.cpp
@@ -9,14 +9,16 @@
 // <https://github.com/ShiromMakkad/MandelbrotPerturbation>
 
 #include "engine/PertEngine.h"
+#include "engine/perturbation.h"
 
+#include "engine/bailout_formula.h"
 #include "engine/calcfrac.h"
 #include "engine/id_data.h"
 #include "fractals/fractalp.h"
 #include "fractals/pickover_mandelbrot.h"
 #include "math/biginit.h"
 #include "math/complex_fn.h"
-#include "misc/Driver.h"
+#include "misc/driver.h"
 #include "misc/id.h"
 #include "ui/cmdfiles.h"
 
@@ -28,18 +30,21 @@
 
 // Raising this number makes more calculations, but less variation between each calculation (less chance
 // of mis-identifying a glitched point).
-constexpr double GLITCH_TOLERANCE{1e-6};
+double GLITCH_TOLERANCE = g_perturbation_tolerance;
 
 void PertEngine::initialize_frame(
     const BFComplex &center_bf, const std::complex<double> &center, double zoom_radius)
 {
     m_zoom_radius = zoom_radius;
 
+    cleanup();
     if (g_bf_math != BFMathType::NONE)
     {
         m_saved_stack = save_stack();
         m_center_bf.x = alloc_stack(g_bf_length + 2);
         m_center_bf.y = alloc_stack(g_bf_length + 2);
+        m_c_bf.x = alloc_stack(g_r_bf_length + 2);
+        m_c_bf.y = alloc_stack(g_r_bf_length + 2);
         copy_bf(m_center_bf.x, center_bf.x);
         copy_bf(m_center_bf.y, center_bf.y);
     }
@@ -52,9 +57,7 @@ void PertEngine::initialize_frame(
 // Full frame calculation
 int PertEngine::calculate_one_frame()
 {
-    BFComplex c_bf{};
     BFComplex reference_coordinate_bf;
-    std::complex<double> c;
     std::complex<double> reference_coordinate;
 
     m_reference_points = 0;
@@ -65,6 +68,7 @@ int PertEngine::calculate_one_frame()
     m_glitch_points.resize(g_screen_x_dots * g_screen_y_dots);
     m_perturbation_tolerance_check.resize(g_max_iterations * 2);
     m_xn.resize(g_max_iterations + 1);
+    m_glitches.resize(g_screen_x_dots * g_screen_y_dots);
 
     // calculate the pascal's triangle coefficients for powers > 3
     pascal_triangle();
@@ -76,24 +80,23 @@ int PertEngine::calculate_one_frame()
             Point pt(x, g_screen_y_dots - 1 - y);
             m_points_remaining[y * g_screen_x_dots + x] = pt;
             m_remaining_point_count++;
-        }
+            m_glitches[x + y * g_screen_x_dots] = -1; // not yet processed
+            }
     }
 
     double magnified_radius = m_zoom_radius;
     int window_radius = std::min(g_screen_x_dots, g_screen_y_dots);
-    BigStackSaver saved;
+    int saved = save_stack();
     BigFloat tmp_bf;
 
     if (g_bf_math != BFMathType::NONE)
     {
-        c_bf.x = alloc_stack(g_r_bf_length + 2);
-        c_bf.y = alloc_stack(g_r_bf_length + 2);
         reference_coordinate_bf.x = alloc_stack(g_r_bf_length + 2);
         reference_coordinate_bf.y = alloc_stack(g_r_bf_length + 2);
         tmp_bf = alloc_stack(g_r_bf_length + 2);
     }
 
-    while (m_remaining_point_count > (g_screen_x_dots * g_screen_y_dots) * (m_percent_glitch_tolerance / 100))
+    if (m_remaining_point_count > (g_screen_x_dots * g_screen_y_dots) * (m_percent_glitch_tolerance / 100))
     {
         m_reference_points++;
 
@@ -103,15 +106,16 @@ int PertEngine::calculate_one_frame()
         {
             if (g_bf_math != BFMathType::NONE)
             {
-                copy_bf(c_bf.x, m_center_bf.x);
-                copy_bf(c_bf.y, m_center_bf.y);
-                copy_bf(reference_coordinate_bf.x, c_bf.x);
-                copy_bf(reference_coordinate_bf.y, c_bf.y);
+                copy_bf(m_c_bf.x, m_center_bf.x);
+                copy_bf(m_c_bf.y, m_center_bf.y);
+                copy_bf(reference_coordinate_bf.x, m_c_bf.x);
+                copy_bf(reference_coordinate_bf.y, m_c_bf.y);
             }
             else
             {
-                c = m_center;
+                m_c = m_center;
                 reference_coordinate = m_center;
+                m_old_reference_coordinate = reference_coordinate;
             }
 
             m_delta_real = 0;
@@ -128,82 +132,13 @@ int PertEngine::calculate_one_frame()
         }
         else
         {
-            if (!m_calculate_glitches)
-            {
-                break;
-            }
-
-            std::srand(g_random_seed);
-            if (!g_random_seed_flag)
-            {
-                ++g_random_seed;
-            }
-            const int index{(int) ((double) std::rand() / RAND_MAX * m_remaining_point_count)};
-            Point pt{m_points_remaining[index]};
-            // Get the complex point at the chosen reference point
-            double delta_real = magnified_radius * (2 * pt.get_x() - g_screen_x_dots) / window_radius;
-            double delta_imag = -magnified_radius * (2 * pt.get_y() - g_screen_y_dots) / window_radius;
-
-            // We need to store this offset because the formula we use to convert pixels into a complex point
-            // does so relative to the center of the image. We need to offset that calculation when our
-            // reference point isn't in the center. The actual offsetting is done in calculate point.
-
-            m_delta_real = delta_real;
-            m_delta_imag = delta_imag;
-
-            if (g_bf_math != BFMathType::NONE)
-            {
-                float_to_bf(tmp_bf, delta_real);
-                add_bf(reference_coordinate_bf.x, c_bf.x, tmp_bf);
-                float_to_bf(tmp_bf, delta_imag);
-                add_bf(reference_coordinate_bf.y, c_bf.y, tmp_bf);
-            }
-            else
-            {
-                reference_coordinate.real(c.real() + delta_real);
-                reference_coordinate.imag(c.imag() + delta_imag);
-            }
-
-            if (g_bf_math != BFMathType::NONE)
-            {
-                reference_zoom_point(reference_coordinate_bf, g_max_iterations);
-            }
-            else
-            {
-                reference_zoom_point(reference_coordinate, g_max_iterations);
-            }
+            restore_stack(saved);
+            return 0;
         }
-
-        int last_checked{-1};
-        m_glitch_point_count = 0;
-        for (int i = 0; i < m_remaining_point_count; i++)
-        {
-            if (i % 1000 == 0 && driver_key_pressed())
-            {
-                return -1;
-            }
-            Point pt{m_points_remaining[i]};
-            if (calculate_point(pt, magnified_radius, window_radius) < 0)
-            {
-                return -1;
-            }
-            // Everything else in this loop is just for updating the progress counter.
-            double progress = (double) i / m_remaining_point_count;
-            if (int(progress * 100) != last_checked)
-            {
-                last_checked = int(progress * 100);
-                m_status = "Pass: " + std::to_string(m_reference_points) + ", Ref (" +
-                    std::to_string(int(progress * 100)) + "%)";
-            }
-        }
-
-        // These points are glitched, so we need to mark them for recalculation. We need to recalculate them
-        // using Pauldelbrot's glitch fixing method (see calculate point).
-        std::memcpy(m_points_remaining.data(), m_glitch_points.data(), sizeof(Point) * m_glitch_point_count);
-        m_remaining_point_count = m_glitch_point_count;
     }
 
-    cleanup();
+    restore_stack(saved);
+    //    cleanup();
     return 0;
 }
 
@@ -219,232 +154,9 @@ void PertEngine::cleanup()
     m_xn.clear();
 }
 
-int PertEngine::calculate_point(const Point &pt, double magnified_radius, int window_radius)
-{
-    // Get the complex number at this pixel.
-    // This calculates the number relative to the reference point, so we need to translate that to the center
-    // when the reference point isn't in the center. That's why for the first reference,
-    // m_calculated_real_delta and m_calculated_imaginary_delta are 0: it's calculating relative to the
-    // center.
-    const double delta_real =
-        ((magnified_radius * (2 * pt.get_x() - g_screen_x_dots)) / window_radius) - m_delta_real;
-    const double delta_imaginary =
-        ((-magnified_radius * (2 * pt.get_y() - g_screen_y_dots)) / window_radius) - m_delta_imag;
-    std::complex<double> delta_sub_0{delta_real, delta_imaginary};
-    std::complex<double> delta_sub_n{delta_real, delta_imaginary};
-    int iteration{};
-    bool glitched{};
-
-    double min_orbit{1e5}; // orbit value closest to origin
-    long min_index{};      // iteration of min_orbit
-    double magnitude;
-    do
-    {
-        if (g_cur_fractal_specific->pert_pt == nullptr)
-        {
-            throw std::runtime_error("No perturbation point function defined for fractal type (" +
-                std::string{g_cur_fractal_specific->name} + ")");
-        }
-        g_cur_fractal_specific->pert_pt(m_xn[iteration], delta_sub_n, delta_sub_0);
-        iteration++;
-        magnitude = mag_squared(m_xn[iteration] + delta_sub_n);
-
-        if (g_inside_color == BOF60 || g_inside_color == BOF61)
-        {
-            if (magnitude < min_orbit)
-            {
-                min_orbit = magnitude;
-                min_index = iteration + 1L;
-            }
-        }
-
-        // This is Pauldelbrot's glitch detection method. You can see it here:
-        // http://www.fractalforums.com/announcements-and-news/pertubation-theory-glitches-improvement/. As
-        // for why it looks so weird, it's because I've squared both sides of his equation and moved the
-        // |ZsubN| to the other side to be precalculated. For more information, look at where the reference
-        // point is calculated. I also only want to store this point once.
-        if (m_calculate_glitches && !glitched &&
-            magnitude < m_perturbation_tolerance_check[iteration])
-        {
-            m_glitch_points[m_glitch_point_count] = Point(pt.get_x(), pt.get_y(), iteration);
-            m_glitch_point_count++;
-            glitched = true;
-            break;
-        }
-    } while (magnitude < g_magnitude_limit && iteration < g_max_iterations);
-
-    if (!glitched)
-    {
-        int index;
-        const double rq_lim2{std::sqrt(g_magnitude_limit)};
-        const std::complex<double> w{m_xn[iteration] + delta_sub_n};
-
-        if (g_biomorph >= 0)
-        {
-            if (iteration == g_max_iterations)
-            {
-                index = g_max_iterations;
-            }
-            else
-            {
-                if (std::abs(w.real()) < rq_lim2 || std::abs(w.imag()) < rq_lim2)
-                {
-                    index = g_biomorph;
-                }
-                else
-                {
-                    index = iteration % 256;
-                }
-            }
-        }
-        else
-        {
-            switch (g_outside_color)
-            {
-            case 0: // no filter
-                if (iteration == g_max_iterations)
-                {
-                    index = g_max_iterations;
-                }
-                else
-                {
-                    index = iteration % 256;
-                }
-                break;
-
-            case ZMAG:
-                if (iteration == g_max_iterations)
-                {
-                    index = (int) ((w.real() * w.real() + w.imag() + w.imag()) * (g_max_iterations >> 1) + 1);
-                }
-                else
-                {
-                    index = iteration % 256;
-                }
-                break;
-
-            case REAL:
-                if (iteration == g_max_iterations)
-                {
-                    index = g_max_iterations;
-                }
-                else
-                {
-                    index = iteration + (long) w.real() + 7;
-                }
-                break;
-
-            case IMAG:
-                if (iteration == g_max_iterations)
-                {
-                    index = g_max_iterations;
-                }
-                else
-                {
-                    index = iteration + (long) w.imag() + 7;
-                }
-                break;
-
-            case MULT:
-                if (iteration == g_max_iterations)
-                {
-                    index = g_max_iterations;
-                }
-                else if (w.imag())
-                {
-                    index = (long) ((double) iteration * (w.real() / w.imag()));
-                }
-                else
-                {
-                    index = iteration;
-                }
-                break;
-
-            case SUM:
-                if (iteration == g_max_iterations)
-                {
-                    index = g_max_iterations;
-                }
-                else
-                {
-                    index = iteration + (long) (w.real() + w.imag());
-                }
-                break;
-
-            case ATAN:
-                if (iteration == g_max_iterations)
-                {
-                    index = g_max_iterations;
-                }
-                else
-                {
-                    index = (long) std::abs(atan2(w.imag(), w.real()) * 180.0 / PI);
-                }
-                break;
-
-            default:
-                if (g_potential_flag)
-                {
-                    index = potential(mag_squared(w), iteration);
-                }
-                else // no filter
-                {
-                    if (iteration == g_max_iterations)
-                    {
-                        index = g_max_iterations;
-                    }
-                    else
-                    {
-                        index = iteration % 256;
-                    }
-                }
-                break;
-            }
-
-            if (g_inside_color >= 0) // no filter
-            {
-                if (iteration == g_max_iterations)
-                {
-                    index = g_inside_color;
-                }
-                else
-                {
-                    index = iteration % 256;
-                }
-            }
-            else
-            {
-                switch (g_inside_color)
-                {
-                case ZMAG:
-                    if (iteration == g_max_iterations)
-                    {
-                        index = (int) (mag_squared(w) * (g_max_iterations >> 1) + 1);
-                    }
-                    break;
-                case BOF60:
-                    if (iteration == g_max_iterations)
-                    {
-                        index = (int) (std::sqrt(min_orbit) * 75.0);
-                    }
-                    break;
-                case BOF61:
-                    if (iteration == g_max_iterations)
-                    {
-                        index = min_index;
-                    }
-                    break;
-                }
-            }
-        }
-        g_plot(pt.get_x(), g_screen_y_dots - 1 - pt.get_y(), index);
-    }
-    return 0;
-}
-
 void PertEngine::reference_zoom_point(const BFComplex &center, int max_iteration)
 {
-    BigStackSaver saved;
+    int saved = save_stack();
 
     BFComplex z_bf;
     z_bf.x = alloc_stack(g_r_bf_length + 2);
@@ -494,6 +206,7 @@ void PertEngine::reference_zoom_point(const BFComplex &center, int max_iteration
         }
         g_cur_fractal_specific->pert_ref_bf(center, z_bf);
     }
+    restore_stack(saved);
 }
 
 void PertEngine::reference_zoom_point(const std::complex<double> &center, int max_iteration)
@@ -528,4 +241,186 @@ void PertEngine::reference_zoom_point(const std::complex<double> &center, int ma
         }
         g_cur_fractal_specific->pert_ref(center, z);
     }
+}
+
+int PertEngine::perturbation_per_pixel(int x, int y, double bailout)
+{
+    double magnified_radius = m_zoom_radius;
+    int window_radius = std::min(g_screen_x_dots, g_screen_y_dots);
+
+    if (m_glitches[x + y * g_screen_x_dots] == 0) // processed and not glitched
+        return -2;
+
+    const double delta_real =
+        ((magnified_radius * (2 * x - g_screen_x_dots)) / window_radius) - m_delta_real;
+    const double delta_imaginary =
+        ((-magnified_radius * (2 * y - g_screen_y_dots)) / window_radius) - m_delta_imag;
+    m_delta_sub_0 = {delta_real, -delta_imaginary};
+    m_delta_sub_n = m_delta_sub_0;
+    m_points_count++;
+    m_glitched = false;
+    return 0;
+}
+
+int PertEngine::calculate_orbit(int x, int y, long iteration)
+{
+    // Get the complex number at this pixel.
+    // This calculates the number relative to the reference point, so we need to translate that to the center
+    // when the reference point isn't in the center. That's why for the first reference, calculatedRealDelta
+    // and calculatedImaginaryDelta are 0: it's calculating relative to the center.
+
+    std::complex<double> temp, temp1;
+    double magnitude;
+
+    temp1 = m_xn[iteration - 1] + m_delta_sub_n;
+    g_cur_fractal_specific->pert_pt(m_xn[iteration - 1], m_delta_sub_n, m_delta_sub_0);
+
+    if (g_cur_fractal_specific->pert_pt == nullptr)
+    {
+        throw std::runtime_error("No perturbation point function defined for fractal type (" +
+                std::string{g_cur_fractal_specific->name} + ")");
+    }
+    temp = m_xn[iteration] + m_delta_sub_n;
+    m_glitches[x + y * g_screen_x_dots] = 0; // assume not glitched
+    magnitude = mag_squared(temp);
+
+    // This is Pauldelbrot's glitch detection method. You can see it here:
+    // http://www.fractalforums.com/announcements-and-news/pertubation-theory-glitches-improvement/. As for
+    // why it looks so weird, it's because I've squared both sides of his equation and moved the |ZsubN| to
+    // the other side to be precalculated. For more information, look at where the reference point is
+    // calculated. I also only want to store this point once.
+    if (m_calculate_glitches && !m_glitched && magnitude < m_perturbation_tolerance_check[iteration])
+    {
+        m_glitches[x + y * g_screen_x_dots] = 1; // yep, she's glitched
+        Point pt(x, y, iteration);
+        m_glitch_points[m_glitch_point_count] = pt;
+        m_glitch_point_count++;
+        m_glitched = true;
+        return true;
+    }
+    g_new_z.x = temp.real();
+    g_new_z.y = temp.imag();
+    // the following are needed because although perturbation operates in doubles, the math type may not be
+    if (g_bf_math == BFMathType::BIG_NUM)
+    {
+        float_to_bn(g_new_z_bn.x, temp.real());
+        float_to_bn(g_new_z_bn.y, temp.imag());
+    }
+    else if (g_bf_math == BFMathType::BIG_FLT)
+    {
+        float_to_bf(g_new_z_bf.x, temp.real());
+        float_to_bf(g_new_z_bf.y, temp.imag());
+    }
+    return g_bailout_float();
+    }
+
+int PertEngine::calculate_reference()
+{
+    double magnified_radius = m_zoom_radius;
+    int window_radius = std::min(g_screen_x_dots, g_screen_y_dots);
+    BFComplex reference_coordinate_bf{};
+    BigFloat tmp_bf{};
+    std::complex<double> reference_coordinate;
+    int saved = save_stack();
+
+    if (m_calculate_glitches == false)
+        return 0;
+
+    if (g_bf_math != BFMathType::NONE)
+    {
+        reference_coordinate_bf.x = alloc_stack(g_r_bf_length + 2);
+        reference_coordinate_bf.y = alloc_stack(g_r_bf_length + 2);
+        tmp_bf = alloc_stack(g_r_bf_length + 2);
+    }
+
+    // These points are glitched, so we need to mark them for recalculation. We need to recalculate them
+    // using Pauldelbrot's glitch fixing method (see calculate point).
+    std::memcpy(m_points_remaining.data(), m_glitch_points.data(), sizeof(Point) * m_glitch_point_count);
+    m_remaining_point_count = m_glitch_point_count;
+
+    std::srand(g_random_seed);
+    if (!g_random_seed_flag)
+    {
+        ++g_random_seed;
+    }
+
+    m_reference_points++;
+
+    const int index{(int) ((double) std::rand() / RAND_MAX * m_remaining_point_count)};
+    Point pt{m_points_remaining[index]};
+    // Get the complex point at the chosen reference point
+    double delta_real = magnified_radius * (2 * pt.get_x() - g_screen_x_dots) / window_radius;
+    double delta_imag = -magnified_radius * (2 * pt.get_y() - g_screen_y_dots) / window_radius;
+
+    // We need to store this offset because the formula we use to convert pixels into a complex point
+    // does so relative to the center of the image. We need to offset that calculation when our
+    // reference point isn't in the center. The actual offsetting is done in calculate point.
+
+    m_delta_real = delta_real;
+    m_delta_imag = delta_imag;
+
+    if (g_bf_math != BFMathType::NONE)
+    {
+        float_to_bf(tmp_bf, delta_real);
+        add_bf(reference_coordinate_bf.x, m_c_bf.x, tmp_bf);
+        float_to_bf(tmp_bf, delta_imag);
+        sub_bf(reference_coordinate_bf.y, m_c_bf.y, tmp_bf);
+    }
+    else
+    {
+        reference_coordinate.real(m_c.real() + delta_real);
+        reference_coordinate.imag(m_c.imag() - delta_imag);
+    }
+
+    if (g_bf_math != BFMathType::NONE)
+    {
+        reference_zoom_point(reference_coordinate_bf, g_max_iterations);
+    }
+    else
+    {
+        reference_zoom_point(reference_coordinate, g_max_iterations);
+    }
+
+    if (g_bf_math != BFMathType::NONE)
+    {
+        restore_stack(saved);
+    }
+
+    m_glitch_point_count = 0;
+    return 0;
+}
+
+long PertEngine::get_glitch_point_count()
+{
+    return (m_remaining_point_count > (g_screen_x_dots * g_screen_y_dots) * (m_percent_glitch_tolerance / 100));
+}
+
+void PertEngine::push_glitch(int x, int y, int value)
+{
+    m_glitches[x + y * g_screen_x_dots] = value;
+}
+
+bool PertEngine::is_glitched()
+{
+    return m_glitched;
+}
+
+bool PertEngine::is_pixel_complete(int x, int y)
+{
+    return (m_glitches[x + y * g_screen_x_dots] == 0);
+}
+
+void PertEngine::set_glitched(bool status)
+{
+    m_glitched = status;
+}
+
+void PertEngine::set_points_count(long count)
+{
+    m_points_count = count;
+}
+
+void PertEngine::set_glitch_points_count(long count)
+{
+    m_glitch_point_count = count;
 }

--- a/libid/engine/calcfrac.cpp
+++ b/libid/engine/calcfrac.cpp
@@ -35,6 +35,7 @@
 #include "engine/tesseral.h"
 #include "engine/wait_until.h"
 #include "engine/work_list.h"
+#include "engine/perturbation.h"
 #include "fractals/fractalp.h"
 #include "fractals/frothy_basin.h"
 #include "fractals/lyapunov.h"
@@ -46,7 +47,7 @@
 #include "math/mpmath.h"
 #include "math/sign.h"
 #include "misc/debug_flags.h"
-#include "misc/Driver.h"
+#include "misc/driver.h"
 #include "ui/cmdfiles.h"
 #include "ui/diskvid.h"
 #include "ui/find_special_colors.h"
@@ -184,6 +185,7 @@ int g_periodicity_next_saved_incr{};             // For periodicity testing, onl
 long g_first_saved_and{};                        //
 int g_atan_colors{180};                          //
 int g_and_color{};                               // "and" value used for color selection
+bool g_pixel_is_complete = false;                // flag to indicate no further calculations are required on this pixel
 
 static double fmod_test_bailout_or()
 {
@@ -880,11 +882,37 @@ int find_alternate_math(FractalType type, BFMathType math)
 // general escape-time engine routines
 static void perform_work_list()
 {
+    if (bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
+    {
+        if (g_perturbation == PerturbationMode::AUTO && g_bf_math != BFMathType::NONE)
+        {
+            g_use_perturbation = true;
+        }
+        else if (g_perturbation == PerturbationMode::YES)
+        {
+            g_use_perturbation = true;
+        }
+        else
+        {
+            g_use_perturbation = false;
+        }
+    }
+    else
+    {
+        g_use_perturbation = false;
+    }
+
     int (*sv_orbit_calc)() = nullptr;  // function that calculates one orbit
     int (*sv_per_pixel)() = nullptr;  // once-per-pixel init
     bool (*sv_per_image)() = nullptr;  // once-per-image setup
     int alt = find_alternate_math(g_fractal_type, g_bf_math);
+    bool processing_glitches = false;
 
+        // start experimental perturbation code
+    if (g_use_perturbation)
+    {
+        mandel_perturbation_setup();
+    }
     if (alt > -1)
     {
         sv_orbit_calc = g_cur_fractal_specific->orbit_calc;
@@ -1016,9 +1044,15 @@ static void perform_work_list()
     {
         // per_image can override
         g_calc_type = g_cur_fractal_specific->calc_type;
-        g_symmetry = g_cur_fractal_specific->symmetry; //   calctype & symmetry
+        if (g_use_perturbation)
+        {
+            g_symmetry = SymmetryType::NONE;            // symmetry causes crashes in perturbation
+        }
+        else
+        {
+            g_symmetry = g_cur_fractal_specific->symmetry; //   calctype & symmetry
+        }
         g_plot = g_put_color; // defaults when setsymmetry not called or does nothing
-
         // pull top entry off worklist
         g_xx_start = g_work_list[0].xx_start;
         g_i_x_start = g_work_list[0].xx_start;
@@ -1040,7 +1074,10 @@ static void perform_work_list()
 
         g_calc_status = CalcStatus::IN_PROGRESS; // mark as in-progress
 
-        g_cur_fractal_specific->per_image();
+        if (!g_use_perturbation)
+        {
+            g_cur_fractal_specific->per_image();
+        }
         if (g_show_dot >= 0)
         {
             find_special_colors();
@@ -1153,12 +1190,7 @@ static void perform_work_list()
             break;
 
         case 'g':
-            // TODO: fix this
-            // horrible cludge preventing crash when coming back from perturbation and math = bignum/bigflt
-            if (g_calc_status != CalcStatus::COMPLETED)
-            {
-                solid_guess();
-            }
+            solid_guess();
             break;
 
         case 'd':
@@ -1167,14 +1199,6 @@ static void perform_work_list()
 
         case 'o':
             sticky_orbits();
-            break;
-
-        case 'p':
-            // we already finished perturbation
-            if (bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
-            {
-                return;
-            }
             break;
 
         default:
@@ -1190,11 +1214,26 @@ static void perform_work_list()
         {
             break;
         }
+        if (g_use_perturbation)
+        {
+            if (get_glitch_point_count())
+            {
+                calculate_reference(); // get next reference if we still have enough glitched pixels
+                g_num_work_list++;
+                processing_glitches = true;
+                continue;
+            }
+            else
+            {
+                processing_glitches = false;
+                cleanup_perturbation(); // all done
+            }
+        }
     }
 
     if (g_num_work_list > 0)
     {
-        // interrupted, resumable
+         // interrupted, resumable
         alloc_resume(sizeof(g_work_list)+20, 2);
         put_resume_len(sizeof(g_num_work_list), &g_num_work_list, sizeof(g_work_list), g_work_list, 0);
     }
@@ -1460,7 +1499,23 @@ int standard_fractal()       // per pixel 1/2/b/g, called with row & col set
     }
     g_overflow = false;           // reset integer math overflow flag
 
-    g_cur_fractal_specific->per_pixel(); // initialize the calculations
+    if (g_use_perturbation)
+    {
+        g_pixel_is_complete = false;
+        int temp_color = get_color(g_col, g_row);
+        if (perturbation_per_pixel() == -2) // initialize the calculations -2 means not glitched
+        {
+            g_color_iter = temp_color; // we have done this pixel in an earlier pass and it's not glitched//
+            g_color = std::abs((int) g_color_iter);
+            g_pixel_is_complete = true;
+            return g_color;
+        }
+    }
+    else
+    {
+        g_cur_fractal_specific->per_pixel(); // initialize the calculations
+    }
+
 
     attracted = false;
 
@@ -1565,9 +1620,22 @@ int standard_fractal()       // per pixel 1/2/b/g, called with row & col set
         }
 
         // the usual case
-        else if ((g_cur_fractal_specific->orbit_calc() && g_inside_color != STAR_TRAIL) || g_overflow)
+        else
         {
-            break;
+            if (g_use_perturbation)
+            {
+                if ((perturbation_per_orbit() && g_inside_color != STAR_TRAIL) || g_overflow)
+                {
+                    break;
+                }
+            }
+            else
+            {
+                if ((g_cur_fractal_specific->orbit_calc() && g_inside_color != STAR_TRAIL) || g_overflow)
+                {
+                    break;
+                }
+            }
         }
         if (g_show_orbit)
         {
@@ -2089,12 +2157,12 @@ plot_inside: // we're "inside"
         {
             if (hooper == 1)
             {
-                constexpr int GREEN = 2;
+                int const GREEN = 2;
                 g_color_iter = GREEN;
             }
             else if (hooper == 2)
             {
-                constexpr int YELLOW = 6;
+                int const YELLOW = 6;
                 g_color_iter = YELLOW;
             }
             else if (hooper == 0)

--- a/libid/engine/fractalb.cpp
+++ b/libid/engine/fractalb.cpp
@@ -355,15 +355,6 @@ bool mandel_bn_setup()
         }
     }
 
-    if (g_std_calc_mode == 'p' && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
-    {
-        mandel_perturbation_setup();
-        // TODO: figure out crash if we don't do this
-        g_std_calc_mode ='g';
-        g_calc_status = CalcStatus::COMPLETED;
-        return true;
-    }
-
     g_c_exponent = (int) g_params[2];
     switch (g_fractal_type)
     {
@@ -474,10 +465,6 @@ bool mandel_bf_setup()
     {
     case FractalType::MANDEL_FP:
     case FractalType::BURNING_SHIP:
-        if (g_std_calc_mode == 'p' && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
-        {
-            return mandel_perturbation_setup();
-        }
         break;
 
     case FractalType::JULIA_FP:
@@ -486,19 +473,6 @@ bool mandel_bf_setup()
         break;
 
     case FractalType::MANDEL_Z_POWER_FP:
-        if (g_std_calc_mode == 'p' && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
-        {
-            // only allow integer values of real part
-            if (const int degree = (int) g_params[2]; degree > 2)
-            {
-                return mandel_z_power_perturbation_setup();
-            }
-            else if (degree == 2)
-            {
-                return mandel_perturbation_setup();
-            }
-        }
-
         init_big_pi();
         if ((double) g_c_exponent == g_params[2] && (g_c_exponent & 1)) // odd exponents
         {

--- a/libid/engine/one_or_two_pass.cpp
+++ b/libid/engine/one_or_two_pass.cpp
@@ -80,19 +80,22 @@ static int standard_calc(int pass_num)
                 }
                 g_resuming = false;       // reset so quick_calc works
                 g_reset_periodicity = false;
-                if (pass_num == 1)       // first pass, copy pixel and bump col
+                if (pass_num == 1) // first pass, copy pixel and bump col
                 {
-                    if ((g_row&1) == 0 && g_row < g_i_y_stop)
+                    if (!(g_pixel_is_complete && g_use_perturbation))   // Don't plot pixels if we have already done them'
                     {
-                        (*g_plot)(g_col, g_row+1, g_color);
+                        if ((g_row&1) == 0 && g_row < g_i_y_stop)
+                        {
+                            (*g_plot)(g_col, g_row+1, g_color);
+                            if ((g_col&1) == 0 && g_col < g_i_x_stop)
+                            {
+                                (*g_plot)(g_col+1, g_row+1, g_color);
+                            }
+                        }
                         if ((g_col&1) == 0 && g_col < g_i_x_stop)
                         {
-                            (*g_plot)(g_col+1, g_row+1, g_color);
+                            (*g_plot)(++g_col, g_row, g_color);
                         }
-                    }
-                    if ((g_col&1) == 0 && g_col < g_i_x_stop)
-                    {
-                        (*g_plot)(++g_col, g_row, g_color);
                     }
                 }
             }

--- a/libid/engine/perturbation.cpp
+++ b/libid/engine/perturbation.cpp
@@ -13,13 +13,24 @@
 
 #include <stdexcept>
 #include <string>
+#include <math.h>
 
 static PertEngine s_pert_engine;
 
+PerturbationMode g_perturbation{PerturbationMode::AUTO};
+double g_perturbation_tolerance{1e-6};
+
+extern DComplex g_old_z;
+extern DComplex g_new_z;
+extern int g_row;
+extern int g_col;
+extern long g_color_iter;
+extern double g_magnitude_limit;
+
 bool perturbation()
 {
-    BigStackSaver saved;
-    double mandel_width; // width of display
+    int saved = save_stack();
+    double mandel_width{}; // width of display
     DComplex center{};
     BFComplex center_bf{};
     double x_mag_factor{};
@@ -36,7 +47,20 @@ bool perturbation()
     else
     {
         LDouble magnification_ld;
+        if (isnan(g_x_max) || isnan(g_x_min))
+        {
+            throw std::runtime_error("Failed to calculate x_max or x_min ");
+        }
+        if (isnan(g_y_max) || isnan(g_y_min))
+        {
+            throw std::runtime_error("Failed to calculate y_max or y_min ");
+        }
+
         cvt_center_mag(center.x, center.y, magnification_ld, x_mag_factor, rotation, skew);
+        if (isnan(center.x) || isnan(center.y))
+        {
+            throw std::runtime_error("Failed to calculate perturbation center ");
+        }
         center.y = -center.y;
     }
 
@@ -56,6 +80,51 @@ bool perturbation()
     {
         throw std::runtime_error("Failed to initialize perturbation engine (" + std::to_string(result) + ")");
     }
-    g_calc_status = CalcStatus::COMPLETED;
+    restore_stack(saved);
+    perturbation_per_image();
+//    g_calc_status = CalcStatus::COMPLETED;
     return false;
+}
+
+int perturbation_per_orbit()
+{
+    int status = s_pert_engine.calculate_orbit(g_col, g_row, g_color_iter);
+    return status;
+}
+
+int perturbation_per_pixel()
+{
+    int result = s_pert_engine.perturbation_per_pixel(g_col, g_row, g_magnitude_limit);
+    return result;
+}
+
+bool perturbation_per_image()
+{
+    if (const int result = s_pert_engine.calculate_one_frame(); result < 0)
+    {
+        throw std::runtime_error("Failed to initialize perturbation engine (" + std::to_string(result) + ")");
+    }
+
+    s_pert_engine.set_glitch_points_count(0);
+    return 0;
+}
+
+bool is_pixel_finished(int x, int y)
+{
+    return (s_pert_engine.is_pixel_complete(x, y));
+}
+
+long get_glitch_point_count()
+{
+    return (s_pert_engine.get_glitch_point_count());
+}
+
+int calculate_reference()
+{
+    return (s_pert_engine.calculate_reference());
+}
+
+void cleanup_perturbation()
+{
+    s_pert_engine.cleanup();
 }

--- a/libid/engine/solid_guess.cpp
+++ b/libid/engine/solid_guess.cpp
@@ -7,7 +7,7 @@
 #include "engine/pixel_limits.h"
 #include "engine/work_list.h"
 #include "misc/debug_flags.h"
-#include "misc/Driver.h"
+#include "misc/driver.h"
 #include "ui/cmdfiles.h"
 #include "ui/video.h"
 
@@ -276,6 +276,13 @@ static bool guess_row(bool first_pass, int y, int block_size)
     unsigned int *pfx_ptr;
     unsigned int pfx_mask;
 
+    /*
+    if (g_pixel_is_complete && g_use_perturbation)
+    {
+        add_work_list(g_xx_start, g_xx_stop, g_xx_start, g_yy_start, g_yy_stop, g_yy_start, 1, g_work_symmetry);
+        return false;
+    }
+    */
     c42 = 0;  // just for warning
     c41 = 0;
     c44 = 0;
@@ -330,7 +337,10 @@ static bool guess_row(bool first_pass, int y, int block_size)
 
         if (first_pass)    // 1st pass, paint topleft corner
         {
-            plot_block(0, x, y, c22);
+            if (!(g_pixel_is_complete && g_use_perturbation))
+            {
+                plot_block(0, x, y, c22);
+            }
         }
         // setup variables
         x_plus_half = x + s_half_block;
@@ -446,36 +456,46 @@ static bool guess_row(bool first_pass, int y, int block_size)
             {
                 if (s_guess_plot)
                 {
-                    if (guessed23 > 0)
+                    if (!(g_pixel_is_complete && g_use_perturbation))
                     {
-                        (*g_plot)(x, y_plus_half, c23);
-                    }
-                    if (guessed32 > 0)
-                    {
-                        (*g_plot)(x_plus_half, y, c32);
-                    }
-                    if (guessed33 > 0)
-                    {
-                        (*g_plot)(x_plus_half, y_plus_half, c33);
+                        if (guessed23 > 0)
+                        {
+                            (*g_plot)(x, y_plus_half, c23);
+                        }
+                        if (guessed32 > 0)
+                        {
+                            (*g_plot)(x_plus_half, y, c32);
+                        }
+                        if (guessed33 > 0)
+                        {
+                            (*g_plot)(x_plus_half, y_plus_half, c33);
+                        }
                     }
                 }
-                plot_block(1, x, y_plus_half, c23);
-                plot_block(0, x_plus_half, y, c32);
-                plot_block(1, x_plus_half, y_plus_half, c33);
+                if (!(g_pixel_is_complete && g_use_perturbation))
+                {
+                    plot_block(1, x, y_plus_half, c23);
+                    plot_block(0, x_plus_half, y, c32);
+                    plot_block(1, x_plus_half, y_plus_half, c33);
+                }
+
             }
             else  // repaint changed blocks
             {
-                if (c23 != c22)
+                if (!(g_pixel_is_complete && g_use_perturbation))
                 {
-                    plot_block(-1, x, y_plus_half, c23);
-                }
-                if (c32 != c22)
-                {
-                    plot_block(-1, x_plus_half, y, c32);
-                }
-                if (c33 != c22)
-                {
-                    plot_block(-1, x_plus_half, y_plus_half, c33);
+                    if (c23 != c22)
+                    {
+                        plot_block(-1, x, y_plus_half, c23);
+                    }
+                    if (c32 != c22)
+                    {
+                        plot_block(-1, x_plus_half, y, c32);
+                    }
+                    if (c33 != c22)
+                    {
+                        plot_block(-1, x_plus_half, y_plus_half, c33);
+                    }
                 }
             }
         }
@@ -503,7 +523,10 @@ static bool guess_row(bool first_pass, int y, int block_size)
             }
             if (s_half_block > 1 && c21 != c22)
             {
-                plot_block(-1, x, y_less_half, c21);
+                if (!(g_pixel_is_complete && g_use_perturbation))
+                {
+                    plot_block(-1, x, y_less_half, c21);
+                }
             }
         }
         if (fix31)
@@ -515,7 +538,10 @@ static bool guess_row(bool first_pass, int y, int block_size)
             }
             if (s_half_block > 1 && c31 != c22)
             {
-                plot_block(-1, x_plus_half, y_less_half, c31);
+                if (!(g_pixel_is_complete && g_use_perturbation))
+                {
+                    plot_block(-1, x_plus_half, y_less_half, c31);
+                }
             }
         }
         if (c23 != c22)
@@ -529,7 +555,10 @@ static bool guess_row(bool first_pass, int y, int block_size)
                 }
                 if (s_half_block > 1 && c12 != c22)
                 {
-                    plot_block(-1, x-s_half_block, y, c12);
+                    if (!(g_pixel_is_complete && g_use_perturbation))
+                    {
+                        plot_block(-1, x - s_half_block, y, c12);
+                    }
                 }
             }
             if (guessed13)
@@ -541,7 +570,10 @@ static bool guess_row(bool first_pass, int y, int block_size)
                 }
                 if (s_half_block > 1 && c13 != c22)
                 {
-                    plot_block(-1, x-s_half_block, y_plus_half, c13);
+                    if (!(g_pixel_is_complete && g_use_perturbation))
+                    {
+                        plot_block(-1, x - s_half_block, y_plus_half, c13);
+                    }
                 }
             }
         }
@@ -567,12 +599,18 @@ static bool guess_row(bool first_pass, int y, int block_size)
         j = y+i;
         if (j <= g_i_y_stop)
         {
+            if (!(g_pixel_is_complete && g_use_perturbation))
+            {
             write_span(j, g_xx_start, g_i_x_stop, &s_stack[g_xx_start]);
+            }
         }
         j = y+i+s_half_block;
         if (j <= g_i_y_stop)
         {
-            write_span(j, g_xx_start, g_i_x_stop, &s_stack[g_xx_start+OLD_MAX_PIXELS]);
+            if (!(g_pixel_is_complete && g_use_perturbation))
+            {
+                write_span(j, g_xx_start, g_i_x_stop, &s_stack[g_xx_start + OLD_MAX_PIXELS]);
+            }
         }
         if (driver_key_pressed())
         {
@@ -601,12 +639,18 @@ static bool guess_row(bool first_pass, int y, int block_size)
             j = g_yy_stop-(y+i-g_yy_start);
             if (j > g_i_y_stop && j < g_logical_screen_y_dots)
             {
-                write_span(j, g_xx_start, g_i_x_stop, &s_stack[g_xx_start]);
+                if (!(g_pixel_is_complete && g_use_perturbation))
+                {
+                    write_span(j, g_xx_start, g_i_x_stop, &s_stack[g_xx_start]);
+                }
             }
             j = g_yy_stop-(y+i+s_half_block-g_yy_start);
             if (j > g_i_y_stop && j < g_logical_screen_y_dots)
             {
-                write_span(j, g_xx_start, g_i_x_stop, &s_stack[g_xx_start+OLD_MAX_PIXELS]);
+                if (!(g_pixel_is_complete && g_use_perturbation))
+                {
+                    write_span(j, g_xx_start, g_i_x_stop, &s_stack[g_xx_start + OLD_MAX_PIXELS]);
+                }
             }
             if (driver_key_pressed())
             {

--- a/libid/fractals/frasetup.cpp
+++ b/libid/fractals/frasetup.cpp
@@ -31,10 +31,6 @@
 bool
 mandel_setup()           // Mandelbrot Routine
 {
-    if (g_std_calc_mode == 'p' && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
-    {
-        return mandel_perturbation_setup();
-    }
     if (g_debug_flag != DebugFlags::FORCE_STANDARD_FRACTAL
         && (g_invert == 0)
         && g_decomp[0] == 0
@@ -71,13 +67,14 @@ bool mandel_perturbation_setup()
 {
     return perturbation();
 }
-
+/*
 bool mandel_z_power_perturbation_setup()
 {
     constexpr int MAX_POWER{28};
     g_c_exponent = std::min(std::max(g_c_exponent, 2), MAX_POWER);
     return perturbation();
 }
+*/
 
 bool
 mandel_fp_setup()
@@ -112,10 +109,6 @@ mandel_fp_setup()
            calcmandfp() can currently handle invert, any rqlim, potflag
            zmag, epsilon cross, and all the current outside options
         */
-        if (g_std_calc_mode == 'p' && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
-        {
-            return mandel_perturbation_setup();
-        }
         if (g_debug_flag != DebugFlags::FORCE_STANDARD_FRACTAL
             && !g_distance_estimator
             && g_decomp[0] == 0
@@ -139,17 +132,6 @@ mandel_fp_setup()
         break;
 
     case FractalType::MANDEL_Z_POWER_FP:
-        if (g_std_calc_mode == 'p' && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
-        {
-            if (g_c_exponent == 2)
-            {
-                return mandel_perturbation_setup();
-            }
-            if (g_c_exponent > 2)
-            {
-                return mandel_z_power_perturbation_setup();
-            }
-        }
         if ((double)g_c_exponent == g_params[2] && (g_c_exponent & 1))   // odd exponents
         {
             g_symmetry = SymmetryType::XY_AXIS_NO_PARAM;

--- a/libid/include/engine/PertEngine.h
+++ b/libid/include/engine/PertEngine.h
@@ -14,12 +14,23 @@ class PertEngine
 public:
     void initialize_frame(const BFComplex &center_bf, const std::complex<double> &center, double zoom_radius);
     int calculate_one_frame();
+    int perturbation_per_pixel(int x, int y, double bailout);
+    int calculate_orbit(int x, int y, long iteration);
+    int calculate_reference();
+    long get_glitch_point_count();
+    void push_glitch(int x, int y, int value);
+    bool is_glitched();
+    bool is_pixel_complete(int x, int y);
+    void set_glitched(bool status);
+    void set_points_count(long count);
+    void set_glitch_points_count(long count);
+    void cleanup();
+
 
 private:
-    int calculate_point(const Point &pt, double magnified_radius, int window_radius);
+//    int calculate_point(const Point &pt, double magnified_radius, int window_radius);
     void reference_zoom_point(const BFComplex &center, int max_iteration);
     void reference_zoom_point(const std::complex<double> &center, int max_iteration);
-    void cleanup();
 
     std::string m_status;
     std::vector<std::complex<double>> m_xn;
@@ -30,11 +41,21 @@ private:
     std::vector<Point> m_glitch_points;
     long m_glitch_point_count{};
     long m_remaining_point_count{};
-    BFComplex m_center_bf{};
+    long m_points_count{};
     std::complex<double> m_center{};
+    BFComplex m_center_bf{};
+    std::complex<double> m_c{};
+    BFComplex m_c_bf{};
     double m_zoom_radius{};
     bool m_calculate_glitches{true};
     double m_percent_glitch_tolerance{0.1}; // What percentage of the image is okay to be glitched.
     int m_reference_points{};
     int m_saved_stack{};
+    std::vector<int> m_glitches{};
+    bool m_glitched{};
+
+    std::complex<double> m_old_reference_coordinate{};
+
+    std::complex<double> m_delta_sub_0{};
+    std::complex<double> m_delta_sub_n{};
 };

--- a/libid/include/engine/one_or_two_pass.h
+++ b/libid/include/engine/one_or_two_pass.h
@@ -3,3 +3,6 @@
 #pragma once
 
 int one_or_two_pass();
+
+extern bool g_pixel_is_complete;  // flag to indicate no further calculations are required on this pixel
+extern bool g_use_perturbation;   // select perturbation code

--- a/libid/include/engine/perturbation.h
+++ b/libid/include/engine/perturbation.h
@@ -3,3 +3,22 @@
 #pragma once
 
 bool perturbation();
+extern bool mandel_perturbation_setup();
+extern bool perturbation_per_image();
+extern int perturbation_per_pixel();
+extern int perturbation_per_orbit();
+extern bool is_pixel_finished(int x, int y);
+extern long get_glitch_point_count();
+extern int calculate_reference();
+extern void cleanup_perturbation();
+
+extern bool g_use_perturbation; // select perturbation code
+
+enum class PerturbationMode
+{
+    AUTO = 0, // the default
+    YES = 1,
+    NO = 2
+};
+extern PerturbationMode g_perturbation;
+extern double g_perturbation_tolerance;

--- a/libid/include/engine/solid_guess.h
+++ b/libid/include/engine/solid_guess.h
@@ -5,3 +5,6 @@
 // used by solid guessing and by zoom panning
 int ssg_block_size();
 int solid_guess();
+
+extern bool g_pixel_is_complete;        // flag to indicate no further calculations are required on this pixel
+extern bool g_use_perturbation;         // select perturbation code

--- a/libid/ui/cmdfiles.cpp
+++ b/libid/ui/cmdfiles.cpp
@@ -18,6 +18,7 @@
 #include "engine/log_map.h"
 #include "engine/soi.h"
 #include "engine/sticky_orbits.h"
+#include "engine/perturbation.h"
 #include "fractals/check_orbit_name.h"
 #include "fractals/fractalp.h"
 #include "fractals/fractype.h"
@@ -3765,8 +3766,34 @@ static CmdArgFlags cmd_xy_shift(const Command &cmd)
     return CmdArgFlags::FRACTAL_PARAM | CmdArgFlags::PARAM_3D;
 }
 
+// tolerance=?
+static CmdArgFlags cmd_tolerance(const Command &cmd)
+{
+    g_perturbation_tolerance = cmd.float_vals[0];
+    return CmdArgFlags::NONE;
+}
+
+// perturbation=?
+static CmdArgFlags cmd_perturbation(const Command &cmd)
+{
+    std::string p = cmd.value;
+    if (p == "auto")
+    {
+        g_perturbation = PerturbationMode::AUTO;
+    }
+    else if (p == "yes")
+    {
+        g_perturbation = PerturbationMode::YES;
+    }
+    else
+    {
+        g_perturbation = PerturbationMode::NO;
+    }
+    return CmdArgFlags::NONE;
+}
+
 // Keep this sorted by parameter name for binary search to work correctly.
-static std::array<CommandHandler, 157> s_commands{
+static std::array<CommandHandler, 159> s_commands{
     CommandHandler{"3d", cmd_3d},                           //
     CommandHandler{"3dmode", cmd_3d_mode},                  //
     CommandHandler{"ambient", cmd_ambient},                 //
@@ -3865,6 +3892,7 @@ static std::array<CommandHandler, 157> s_commands{
     CommandHandler{"passes", cmd_passes},                   //
     CommandHandler{"periodicity", cmd_periodicity},         //
     CommandHandler{"perspective", cmd_perspective},         //
+    CommandHandler{"perturbation", cmd_perturbation},       //
     CommandHandler{"pixelzoom", cmd_pixel_zoom},            //
     CommandHandler{"plotstyle", cmd_deprecated},            // deprecated print parameters
     CommandHandler{"polyphony", cmd_polyphony},             //
@@ -3906,6 +3934,7 @@ static std::array<CommandHandler, 157> s_commands{
     CommandHandler{"tempdir", cmd_temp_dir},                //
     CommandHandler{"textcolors", cmd_text_colors},          //
     CommandHandler{"title", cmd_deprecated},                // deprecated print parameters
+    CommandHandler{"tolerance", cmd_tolerance},             // perturbation glitch tolerance
     CommandHandler{"tplus", cmd_tplus},                     //
     CommandHandler{"translate", cmd_deprecated},            // deprecated print parameters
     CommandHandler{"transparent", cmd_transparent},         //

--- a/libid/ui/get_toggles.cpp
+++ b/libid/ui/get_toggles.cpp
@@ -5,6 +5,7 @@
 #include "engine/calcfrac.h"
 #include "engine/id_data.h"
 #include "engine/log_map.h"
+#include "engine/perturbation.h"
 #include "fractals/fractype.h"
 #include "helpdefs.h"
 #include "ui/cmdfiles.h"
@@ -40,15 +41,16 @@ int get_toggles()
     FullScreenValues values[25];
     int old_sound_flag;
     char const *calc_modes[] = {
-        "1", "2", "3", "g", "g1", "g2", "g3", "g4", "g5", "g6", "b", "s", "t", "d", "o", "p"};
+        "1", "2", "3", "g", "g1", "g2", "g3", "g4", "g5", "g6", "b", "s", "t", "d", "o"};
     char const *sound_modes[5] = {"off", "beep", "x", "y", "z"};
     char const *inside_modes[] = {
         "numb", "maxiter", "zmag", "bof60", "bof61", "epsiloncross", "startrail", "period", "atan", "fmod"};
     char const *outside_modes[] = {"numb", "iter", "real", "imag", "mult", "summ", "atan", "fmod", "tdis"};
+    char const *perturbation_modes[] = {"auto", "yes", "no"};
 
     int k = -1;
 
-    choices[++k] = "Passes (1-3, g[es], b[ound], t[ess], d[iff], o[rbit], p[ert])";
+    choices[++k] = "Passes (1-3, g[es], b[ound], t[ess], d[iff], o[rbit])";
     values[k].type = 'l';
     values[k].uval.ch.vlen = 3;
     values[k].uval.ch.list_len = std::size(calc_modes);
@@ -68,8 +70,8 @@ int get_toggles()
         : (g_user_std_calc_mode == 's') ? 11
         : (g_user_std_calc_mode == 't') ? 12
         : (g_user_std_calc_mode == 'd') ? 13
-        : (g_user_std_calc_mode == 'o') ? 14
-        :        /* "p"erturbation */     15;
+        : /*(g_user_std_calc_mode == 'o') ?*/ 14;
+//        :         "p"erturbation      15;
     char old_user_std_calc_mode = g_user_std_calc_mode;
     int old_stop_pass = g_stop_pass;
     choices[++k] = "Floating Point Algorithm";
@@ -228,6 +230,30 @@ int get_toggles()
     values[k].type = 'f'; // should be 'd', but prompts get messed up
     double old_close_proximity = g_close_proximity;
     values[k].uval.dval = old_close_proximity;
+
+    choices[++k] = "Use Perturbation (yes, no, auto - internal choice)";
+    values[k].type = 'l';
+    values[k].uval.ch.vlen = 4;
+    values[k].uval.ch.list_len = std::size(perturbation_modes);
+    values[k].uval.ch.list = perturbation_modes;
+    PerturbationMode old_perturbation = g_perturbation;
+    if (g_perturbation == PerturbationMode::AUTO)
+    {
+        values[k].uval.ch.val = 0;
+    }
+    else if (g_perturbation == PerturbationMode::YES)
+    {
+        values[k].uval.ch.val = 1;
+    }
+    else
+    {
+        values[k].uval.ch.val = 2;
+    }
+
+    choices[++k] = "Perturbation tolerance";
+    values[k].type = 'd';
+    double old_perturbation_tolerance = g_perturbation_tolerance;
+    values[k].uval.dval = old_perturbation_tolerance;
 
     HelpLabels const old_help_mode = g_help_mode;
     g_help_mode = HelpLabels::HELP_X_OPTIONS;
@@ -417,6 +443,34 @@ int get_toggles()
     ++k;
     g_close_proximity = values[k].uval.dval;
     if (g_close_proximity != old_close_proximity)
+    {
+        j++;
+    }
+
+    int tmp = values[++k].uval.ch.val;
+    if (tmp > 0)
+    {
+        switch (tmp)
+        {
+        case 0:
+            g_perturbation = PerturbationMode::AUTO;
+            break;
+        case 1:
+            g_perturbation = PerturbationMode::YES;
+            break;
+        case 2:
+            g_perturbation = PerturbationMode::NO;
+            break;
+        }
+    }
+
+    if (old_perturbation != g_perturbation)
+    {
+        j++;
+    }
+
+    g_perturbation_tolerance = values[++k].uval.dval;
+    if (old_perturbation_tolerance != g_perturbation_tolerance)
     {
         j++;
     }

--- a/libid/ui/id_main.cpp
+++ b/libid/ui/id_main.cpp
@@ -75,7 +75,8 @@ double g_potential_params[3]{};                                        // three 
 ConfigStatus g_bad_config{};                                           // 'id.cfg' ok?
 bool g_has_inverse{};                                                  //
 int g_integer_fractal{};                                               // TRUE if fractal uses integer math
-                         // user_xxx is what the user wants, vs what we may be forced to do
+bool g_use_perturbation{};                                             // select perturbation code
+                           // user_xxx is what the user wants, vs what we may be forced to do
 char g_user_std_calc_mode{};            //
 int g_user_periodicity_value{};         //
 long g_user_distance_estimator_value{}; //

--- a/libid/ui/make_batch_file.cpp
+++ b/libid/ui/make_batch_file.cpp
@@ -13,6 +13,7 @@
 #include "engine/log_map.h"
 #include "engine/sticky_orbits.h"
 #include "engine/type_has_param.h"
+#include "engine/perturbation.h"
 #include "fractals/fractalp.h"
 #include "fractals/fractype.h"
 #include "fractals/jb.h"
@@ -692,6 +693,16 @@ static void write_batch_params(char const *color_inf, bool colors_only, int max_
         if (g_stop_pass != 0)
         {
             put_param(" %s=%c%c", "passes", g_user_std_calc_mode, (char)g_stop_pass + '0');
+        }
+
+        if (g_perturbation != PerturbationMode::AUTO)
+        {
+            put_param(" %s=%s", "perturbation", (g_perturbation == PerturbationMode::YES) ? "yes" : "no");
+        }
+
+        if (g_perturbation_tolerance != 1e-6)
+        {
+            put_param(" %s=%lg", "tolerance", g_perturbation_tolerance);
         }
 
         if (g_use_center_mag)


### PR DESCRIPTION
Outstanding issues:
Solid_guessing and boundary trace don't work in perturbation. Symmetry is turned off as it causes crashes.

I have found that commenting out line 1232 in calcfrac.cpp (cleanup_perturbation(); // all done) fixes the crash, but then I still have problems in areas o symmetry on the screen. If <vector>.resize() just resizes the existing memory, there's no problem. Otherwise, we will have a memory leak. (I'm still learning C++).