### PR TITLE
Basic pert250319

### DIFF
--- a/libid/engine/PertEngine.cpp
+++ b/libid/engine/PertEngine.cpp
@@ -255,25 +255,35 @@ int PertEngine::calculate_orbit(int x, int y, long iteration)
     // why it looks so weird, it's because I've squared both sides of his equation and moved the |ZsubN| to
     // the other side to be precalculated. For more information, look at where the reference point is
     // calculated. I also only want to store this point once.
-    if (magnitude < m_perturbation_tolerance_check[iteration])
+ //   if (magnitude < m_perturbation_tolerance_check[iteration])
     {
     // here is where the magic happens... eventually
+
+//        calculate_reference(x, y);
 /*
-        calculate_reference(x, y);
         perturbation_per_pixel(x, y, g_magnitude_limit);
         for (long i = 0; i < g_max_iterations; i++)
         {
-            int status = calculate_orbit(x, y, i);
-            if (status == 0)
+            temp1 = m_xn[i] + m_delta_sub_n;
+            g_cur_fractal_specific->pert_pt(m_xn[i], m_delta_sub_n, m_delta_sub_0);
+
+            if (g_cur_fractal_specific->pert_pt == nullptr)
             {
-                g_color_iter = i;
+                throw std::runtime_error("No perturbation point function defined for fractal type (" +
+                    std::string{g_cur_fractal_specific->name} + ")");
+            }
+            temp = m_xn[iteration] + m_delta_sub_n;
+            int status = g_bailout_float();
+            if (status == 1)
+            {
+                g_color_iter = 24;
                 break;
             }
         }
-//        return g_bailout_float();
 */
-        m_reference_points++;
-        return true;
+//        return g_bailout_float();
+//        m_reference_points++;
+ //       return true;
     }
     g_new_z.x = temp.real();
     g_new_z.y = temp.imag();

--- a/libid/engine/PertEngine.cpp
+++ b/libid/engine/PertEngine.cpp
@@ -258,9 +258,21 @@ int PertEngine::calculate_orbit(int x, int y, long iteration)
     if (magnitude < m_perturbation_tolerance_check[iteration])
     {
     // here is where the magic happens... eventually
-    //    calculate_reference(x, y);
-    //    calculate_orbit(x, y, iteration);
-    //    return g_bailout_float();
+/*
+        calculate_reference(x, y);
+        perturbation_per_pixel(x, y, g_magnitude_limit);
+        for (long i = 0; i < g_max_iterations; i++)
+        {
+            int status = calculate_orbit(x, y, i);
+            if (status == 0)
+            {
+                g_color_iter = i;
+                break;
+            }
+        }
+//        return g_bailout_float();
+*/
+        m_reference_points++;
         return true;
     }
     g_new_z.x = temp.real();
@@ -288,7 +300,9 @@ int PertEngine::calculate_reference(int x, int y)
     std::complex<double> reference_coordinate;
     int saved = save_stack();
 
-//    if (m_calculate_glitches == false)
+    m_reference_points++;
+
+    //    if (m_calculate_glitches == false)
 //        return 0;
 
     if (g_bf_math != BFMathType::NONE)
@@ -304,7 +318,6 @@ int PertEngine::calculate_reference(int x, int y)
         ++g_random_seed;
     }
 
-    m_reference_points++;
 
     const int index{(int) ((double) std::rand() / RAND_MAX * m_remaining_point_count)};
     Point pt{m_points_remaining[index]};
@@ -350,4 +363,9 @@ int PertEngine::calculate_reference(int x, int y)
     }
 
     return 0;
+}
+
+int PertEngine::get_number_references()
+{
+    return m_reference_points;
 }

--- a/libid/engine/calcfrac.cpp
+++ b/libid/engine/calcfrac.cpp
@@ -35,6 +35,7 @@
 #include "engine/tesseral.h"
 #include "engine/wait_until.h"
 #include "engine/work_list.h"
+#include "engine/perturbation.h"
 #include "fractals/fractalp.h"
 #include "fractals/frothy_basin.h"
 #include "fractals/lyapunov.h"
@@ -1431,6 +1432,24 @@ int standard_fractal()       // per pixel 1/2/b/g, called with row & col set
     }
     g_overflow = false;           // reset integer math overflow flag
 
+    if (g_use_perturbation)
+    {
+//        int temp_color = get_color(g_col, g_row);
+        perturbation_per_pixel(); // initialize the pert calculations
+//        if (perturbation_per_pixel() == -2) // initialize the calculations -2 means not glitched
+//        {
+//            g_color_iter = temp_color; // we have done this pixel in an earlier pass and it's not glitched//
+//            g_color = std::abs((int) g_color_iter);
+//            g_pixel_is_complete = true;
+//            return g_color;
+//        }
+    }
+    else
+    {
+        g_cur_fractal_specific->per_pixel(); // initialize the calculations
+    }
+
+
     g_cur_fractal_specific->per_pixel(); // initialize the calculations
 
     attracted = false;
@@ -1531,9 +1550,22 @@ int standard_fractal()       // per pixel 1/2/b/g, called with row & col set
         }
 
         // the usual case
-        else if ((g_cur_fractal_specific->orbit_calc() && g_inside_color != STAR_TRAIL) || g_overflow)
+        else
         {
-            break;
+            if (g_use_perturbation)
+            {
+                if ((perturbation_per_orbit() && g_inside_color != STAR_TRAIL) || g_overflow)
+                {
+                    break;
+                }
+            }
+            else
+            {
+                if ((g_cur_fractal_specific->orbit_calc() && g_inside_color != STAR_TRAIL) || g_overflow)
+                {
+                    break;
+                }
+            }
         }
         if (g_show_orbit)
         {

--- a/libid/engine/calcfrac.cpp
+++ b/libid/engine/calcfrac.cpp
@@ -882,6 +882,10 @@ static void perform_work_list()
     bool (*sv_per_image)() = nullptr;  // once-per-image setup
     int alt = find_alternate_math(g_fractal_type, g_bf_math);
 
+    if (g_use_perturbation)             // setup  per-image perturbation
+    {
+        mandel_perturbation_setup();
+    }
     if (alt > -1)
     {
         sv_orbit_calc = g_cur_fractal_specific->orbit_calc;
@@ -1150,10 +1154,10 @@ static void perform_work_list()
         case 'g':
             // TODO: fix this
             // horrible cludge preventing crash when coming back from perturbation and math = bignum/bigflt
-            if (g_calc_status != CalcStatus::COMPLETED)
-            {
+//            if (g_calc_status != CalcStatus::COMPLETED)
+//            {
                 solid_guess();
-            }
+//            }
             break;
 
         case 'd':

--- a/libid/engine/fractalb.cpp
+++ b/libid/engine/fractalb.cpp
@@ -9,6 +9,7 @@
 #include "engine/calcfrac.h"
 #include "engine/fractals.h"
 #include "engine/id_data.h"
+#include "engine/perturbation.h"
 #include "engine/type_has_param.h"
 #include "fractals/divide_brot.h"
 #include "fractals/fractalp.h"
@@ -356,12 +357,12 @@ bool mandel_bn_setup()
         }
     }
 
-    if (g_std_calc_mode == 'p' && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
+    if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
     {
         mandel_perturbation_setup();
         // TODO: figure out crash if we don't do this
-        g_std_calc_mode ='g';
-        g_calc_status = CalcStatus::COMPLETED;
+//        g_std_calc_mode ='g';
+//        g_calc_status = CalcStatus::COMPLETED;
         return true;
     }
 
@@ -475,7 +476,7 @@ bool mandel_bf_setup()
     {
     case FractalType::MANDEL:
     case FractalType::BURNING_SHIP:
-        if (g_std_calc_mode == 'p' && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
+        if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
         {
             return mandel_perturbation_setup();
         }
@@ -487,7 +488,7 @@ bool mandel_bf_setup()
         break;
 
     case FractalType::MANDEL_Z_POWER:
-        if (g_std_calc_mode == 'p' && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
+        if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
         {
             // only allow integer values of real part
             if (const int degree = (int) g_params[2]; degree > 2)
@@ -536,7 +537,7 @@ bool mandel_bf_setup()
 
 int mandel_bn_per_pixel()
 {
-    if (g_std_calc_mode == 'p' && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
+    if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
     {
         return true;
     }

--- a/libid/engine/fractalb.cpp
+++ b/libid/engine/fractalb.cpp
@@ -356,16 +356,7 @@ bool mandel_bn_setup()
             half_a_bn(g_close_enough_bn);
         }
     }
-/*
-    if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
-    {
-        mandel_perturbation_setup();
-        // TODO: figure out crash if we don't do this
-//        g_std_calc_mode ='g';
-//        g_calc_status = CalcStatus::COMPLETED;
-        return true;
-    }
-*/
+
     g_c_exponent = (int) g_params[2];
     switch (g_fractal_type)
     {
@@ -476,12 +467,6 @@ bool mandel_bf_setup()
     {
     case FractalType::MANDEL:
     case FractalType::BURNING_SHIP:
-/*
-        if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
-        {
-            return mandel_perturbation_setup();
-        }
-*/
         break;
 
     case FractalType::JULIA:
@@ -490,20 +475,6 @@ bool mandel_bf_setup()
         break;
 
     case FractalType::MANDEL_Z_POWER:
-/*
-        if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
-        {
-            // only allow integer values of real part
-            if (const int degree = (int) g_params[2]; degree > 2)
-            {
-                return mandel_z_power_perturbation_setup();
-            }
-            else if (degree == 2)
-            {
-                return mandel_perturbation_setup();
-            }
-        }
-*/
         init_big_pi();
         if ((double) g_c_exponent == g_params[2] && (g_c_exponent & 1)) // odd exponents
         {

--- a/libid/engine/fractalb.cpp
+++ b/libid/engine/fractalb.cpp
@@ -356,7 +356,7 @@ bool mandel_bn_setup()
             half_a_bn(g_close_enough_bn);
         }
     }
-
+/*
     if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
     {
         mandel_perturbation_setup();
@@ -365,7 +365,7 @@ bool mandel_bn_setup()
 //        g_calc_status = CalcStatus::COMPLETED;
         return true;
     }
-
+*/
     g_c_exponent = (int) g_params[2];
     switch (g_fractal_type)
     {
@@ -476,10 +476,12 @@ bool mandel_bf_setup()
     {
     case FractalType::MANDEL:
     case FractalType::BURNING_SHIP:
+/*
         if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
         {
             return mandel_perturbation_setup();
         }
+*/
         break;
 
     case FractalType::JULIA:
@@ -488,6 +490,7 @@ bool mandel_bf_setup()
         break;
 
     case FractalType::MANDEL_Z_POWER:
+/*
         if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
         {
             // only allow integer values of real part
@@ -500,7 +503,7 @@ bool mandel_bf_setup()
                 return mandel_perturbation_setup();
             }
         }
-
+*/
         init_big_pi();
         if ((double) g_c_exponent == g_params[2] && (g_c_exponent & 1)) // odd exponents
         {

--- a/libid/engine/perturbation.cpp
+++ b/libid/engine/perturbation.cpp
@@ -7,6 +7,7 @@
 #include "engine/PertEngine.h"
 #include "engine/convert_center_mag.h"
 #include "engine/id_data.h"
+#include "fractals/fractalp.h"
 #include "math/biginit.h"
 
 #include <config/port.h>
@@ -82,3 +83,26 @@ int get_number_references()
     return s_pert_engine.get_number_references();
 }
 
+bool is_perturbation()
+{
+    if (bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
+    {
+        if (g_perturbation == PerturbationMode::AUTO && g_bf_math != BFMathType::NONE)
+        {
+            g_use_perturbation = true;
+        }
+        else if (g_perturbation == PerturbationMode::YES)
+        {
+            g_use_perturbation = true;
+        }
+        else
+        {
+            g_use_perturbation = false;
+        }
+    }
+    else
+    {
+        g_use_perturbation = false;
+    }
+    return g_use_perturbation;
+}

--- a/libid/engine/perturbation.cpp
+++ b/libid/engine/perturbation.cpp
@@ -16,6 +16,10 @@
 
 static PertEngine s_pert_engine;
 
+PerturbationMode g_perturbation{PerturbationMode::AUTO};
+double g_perturbation_tolerance{1e-6};
+bool g_use_perturbation{}; // select perturbation code
+
 bool perturbation()
 {
     BigStackSaver saved;
@@ -58,4 +62,16 @@ bool perturbation()
     }
     g_calc_status = CalcStatus::COMPLETED;
     return false;
+}
+
+int perturbation_per_pixel()
+{
+    int result = s_pert_engine.perturbation_per_pixel(g_col, g_row, g_magnitude_limit);
+    return result;
+}
+
+int perturbation_per_orbit()
+{
+    int status = s_pert_engine.calculate_orbit(g_col, g_row, g_color_iter);
+    return status;
 }

--- a/libid/engine/perturbation.cpp
+++ b/libid/engine/perturbation.cpp
@@ -19,6 +19,7 @@ static PertEngine s_pert_engine;
 PerturbationMode g_perturbation{PerturbationMode::AUTO};
 double g_perturbation_tolerance{1e-6};
 bool g_use_perturbation{}; // select perturbation code
+int g_number_referrences{}; // number of references used
 
 bool perturbation()
 {
@@ -75,3 +76,9 @@ int perturbation_per_orbit()
     int status = s_pert_engine.calculate_orbit(g_col, g_row, g_color_iter);
     return status;
 }
+
+int get_number_references()
+{
+    return s_pert_engine.get_number_references();
+}
+

--- a/libid/fractals/frasetup.cpp
+++ b/libid/fractals/frasetup.cpp
@@ -30,7 +30,7 @@
 // Mandelbrot Routine
 bool mandel_setup()
 {
-    if (g_std_calc_mode == 'p' && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
+    if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
     {
         return mandel_perturbation_setup();
     }
@@ -91,7 +91,7 @@ mandel_fp_setup()
            calcmandfp() can currently handle invert, any rqlim, potflag
            zmag, epsilon cross, and all the current outside options
         */
-        if (g_std_calc_mode == 'p' && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
+        if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
         {
             return mandel_perturbation_setup();
         }
@@ -118,7 +118,7 @@ mandel_fp_setup()
         break;
 
     case FractalType::MANDEL_Z_POWER:
-        if (g_std_calc_mode == 'p' && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
+        if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
         {
             if (g_c_exponent == 2)
             {

--- a/libid/fractals/frasetup.cpp
+++ b/libid/fractals/frasetup.cpp
@@ -44,6 +44,7 @@ standalone_setup()
 
 bool mandel_perturbation_setup()
 {
+    g_calc_type = standard_fractal;
     return perturbation();
 }
 
@@ -90,6 +91,7 @@ mandel_fp_setup()
             && g_use_init_orbit != InitOrbitMode::VALUE
             && (g_sound_flag & SOUNDFLAG_ORBIT_MASK) < SOUNDFLAG_X
             && !g_using_jiim
+            && !g_use_perturbation
             && g_bailout_test == Bailout::MOD
             && (g_orbit_save_flags & OSF_MIDI) == 0)
         {

--- a/libid/fractals/frasetup.cpp
+++ b/libid/fractals/frasetup.cpp
@@ -30,10 +30,12 @@
 // Mandelbrot Routine
 bool mandel_setup()
 {
+/*
     if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
     {
         return mandel_perturbation_setup();
     }
+*/
     // use the main processing loop
     g_calc_type = standard_fractal;
     return true;
@@ -50,14 +52,14 @@ bool mandel_perturbation_setup()
 {
     return perturbation();
 }
-
+/*
 bool mandel_z_power_perturbation_setup()
 {
     constexpr int MAX_POWER{28};
     g_c_exponent = std::min(std::max(g_c_exponent, 2), MAX_POWER);
     return perturbation();
 }
-
+*/
 bool
 mandel_fp_setup()
 {
@@ -91,10 +93,12 @@ mandel_fp_setup()
            calcmandfp() can currently handle invert, any rqlim, potflag
            zmag, epsilon cross, and all the current outside options
         */
+        /*
         if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
         {
             return mandel_perturbation_setup();
         }
+        */
         if (g_debug_flag != DebugFlags::FORCE_STANDARD_FRACTAL
             && !g_distance_estimator
             && g_decomp[0] == 0
@@ -118,6 +122,7 @@ mandel_fp_setup()
         break;
 
     case FractalType::MANDEL_Z_POWER:
+/*
         if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
         {
             if (g_c_exponent == 2)
@@ -129,6 +134,7 @@ mandel_fp_setup()
                 return mandel_z_power_perturbation_setup();
             }
         }
+*/
         if ((double)g_c_exponent == g_params[2] && (g_c_exponent & 1))   // odd exponents
         {
             g_symmetry = SymmetryType::XY_AXIS_NO_PARAM;

--- a/libid/fractals/frasetup.cpp
+++ b/libid/fractals/frasetup.cpp
@@ -30,12 +30,6 @@
 // Mandelbrot Routine
 bool mandel_setup()
 {
-/*
-    if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
-    {
-        return mandel_perturbation_setup();
-    }
-*/
     // use the main processing loop
     g_calc_type = standard_fractal;
     return true;
@@ -52,14 +46,7 @@ bool mandel_perturbation_setup()
 {
     return perturbation();
 }
-/*
-bool mandel_z_power_perturbation_setup()
-{
-    constexpr int MAX_POWER{28};
-    g_c_exponent = std::min(std::max(g_c_exponent, 2), MAX_POWER);
-    return perturbation();
-}
-*/
+
 bool
 mandel_fp_setup()
 {
@@ -93,12 +80,7 @@ mandel_fp_setup()
            calcmandfp() can currently handle invert, any rqlim, potflag
            zmag, epsilon cross, and all the current outside options
         */
-        /*
-        if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
-        {
-            return mandel_perturbation_setup();
-        }
-        */
+        
         if (g_debug_flag != DebugFlags::FORCE_STANDARD_FRACTAL
             && !g_distance_estimator
             && g_decomp[0] == 0
@@ -122,19 +104,6 @@ mandel_fp_setup()
         break;
 
     case FractalType::MANDEL_Z_POWER:
-/*
-        if (g_use_perturbation && bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
-        {
-            if (g_c_exponent == 2)
-            {
-                return mandel_perturbation_setup();
-            }
-            if (g_c_exponent > 2)
-            {
-                return mandel_z_power_perturbation_setup();
-            }
-        }
-*/
         if ((double)g_c_exponent == g_params[2] && (g_c_exponent & 1))   // odd exponents
         {
             g_symmetry = SymmetryType::XY_AXIS_NO_PARAM;

--- a/libid/include/engine/PertEngine.h
+++ b/libid/include/engine/PertEngine.h
@@ -14,6 +14,8 @@ class PertEngine
 public:
     void initialize_frame(const BFComplex &center_bf, const std::complex<double> &center, double zoom_radius);
     int calculate_one_frame();
+    int perturbation_per_pixel(int x, int y, double bailout);
+    int calculate_orbit(int x, int y, long iteration);
 
 private:
     int calculate_point(const Point &pt, double magnified_radius, int window_radius);
@@ -37,4 +39,7 @@ private:
     double m_percent_glitch_tolerance{0.1}; // What percentage of the image is okay to be glitched.
     int m_reference_points{};
     int m_saved_stack{};
+
+    std::complex<double> m_delta_sub_0{};
+    std::complex<double> m_delta_sub_n{};
 };

--- a/libid/include/engine/PertEngine.h
+++ b/libid/include/engine/PertEngine.h
@@ -18,7 +18,7 @@ public:
     int calculate_orbit(int x, int y, long iteration);
 
 private:
-    int calculate_point(const Point &pt, double magnified_radius, int window_radius);
+    int calculate_reference(int x, int y);
     void reference_zoom_point(const BFComplex &center, int max_iteration);
     void reference_zoom_point(const std::complex<double> &center, int max_iteration);
     void cleanup();
@@ -28,17 +28,14 @@ private:
     std::vector<double> m_perturbation_tolerance_check;
     double m_delta_real{};
     double m_delta_imag{};
-    std::vector<Point> m_points_remaining;
-    std::vector<Point> m_glitch_points;
-    long m_glitch_point_count{};
-    long m_remaining_point_count{};
     BFComplex m_center_bf{};
     std::complex<double> m_center{};
     double m_zoom_radius{};
-    bool m_calculate_glitches{true};
     double m_percent_glitch_tolerance{0.1}; // What percentage of the image is okay to be glitched.
     int m_reference_points{};
     int m_saved_stack{};
+    std::complex<double> m_c{};
+    BFComplex m_c_bf{};
 
     std::complex<double> m_delta_sub_0{};
     std::complex<double> m_delta_sub_n{};

--- a/libid/include/engine/PertEngine.h
+++ b/libid/include/engine/PertEngine.h
@@ -16,6 +16,7 @@ public:
     int calculate_one_frame();
     int perturbation_per_pixel(int x, int y, double bailout);
     int calculate_orbit(int x, int y, long iteration);
+    int get_number_references();
 
 private:
     int calculate_reference(int x, int y);

--- a/libid/include/engine/perturbation.h
+++ b/libid/include/engine/perturbation.h
@@ -4,7 +4,7 @@
 
 bool perturbation();
 extern bool mandel_perturbation_setup();
-//extern bool perturbation_per_image();
+extern bool is_perturbation();
 extern int perturbation_per_pixel();
 extern int perturbation_per_orbit();
 //extern bool is_pixel_finished(int x, int y);

--- a/libid/include/engine/perturbation.h
+++ b/libid/include/engine/perturbation.h
@@ -3,3 +3,27 @@
 #pragma once
 
 bool perturbation();
+extern bool mandel_perturbation_setup();
+extern bool perturbation_per_image();
+extern int perturbation_per_pixel();
+extern int perturbation_per_orbit();
+extern bool is_pixel_finished(int x, int y);
+extern long get_glitch_point_count();
+extern int calculate_reference();
+extern void cleanup_perturbation();
+
+extern bool g_use_perturbation; // select perturbation code
+
+extern int g_row;
+extern int g_col;
+extern long g_color_iter;
+extern double g_magnitude_limit;
+
+enum class PerturbationMode
+{
+    AUTO = 0, // the default
+    YES = 1,
+    NO = 2
+};
+extern PerturbationMode g_perturbation;
+extern double g_perturbation_tolerance;

--- a/libid/include/engine/perturbation.h
+++ b/libid/include/engine/perturbation.h
@@ -4,13 +4,14 @@
 
 bool perturbation();
 extern bool mandel_perturbation_setup();
-extern bool perturbation_per_image();
+//extern bool perturbation_per_image();
 extern int perturbation_per_pixel();
 extern int perturbation_per_orbit();
-extern bool is_pixel_finished(int x, int y);
-extern long get_glitch_point_count();
-extern int calculate_reference();
-extern void cleanup_perturbation();
+//extern bool is_pixel_finished(int x, int y);
+//extern long get_glitch_point_count();
+//extern int calculate_reference();
+//extern void cleanup_perturbation();
+extern int get_number_references();
 
 extern bool g_use_perturbation; // select perturbation code
 

--- a/libid/ui/cmdfiles.cpp
+++ b/libid/ui/cmdfiles.cpp
@@ -16,6 +16,7 @@
 #include "engine/get_prec_big_float.h"
 #include "engine/id_data.h"
 #include "engine/log_map.h"
+#include "engine/perturbation.h"
 #include "engine/soi.h"
 #include "engine/sticky_orbits.h"
 #include "fractals/check_orbit_name.h"
@@ -3759,8 +3760,34 @@ static CmdArgFlags cmd_xy_shift(const Command &cmd)
     return CmdArgFlags::FRACTAL_PARAM | CmdArgFlags::PARAM_3D;
 }
 
+// tolerance=?
+static CmdArgFlags cmd_tolerance(const Command &cmd)
+{
+    g_perturbation_tolerance = cmd.float_vals[0];
+    return CmdArgFlags::NONE;
+}
+
+// perturbation=?
+static CmdArgFlags cmd_perturbation(const Command &cmd)
+{
+    std::string p = cmd.value;
+    if (p == "auto")
+    {
+        g_perturbation = PerturbationMode::AUTO;
+    }
+    else if (p == "yes")
+    {
+        g_perturbation = PerturbationMode::YES;
+    }
+    else
+    {
+        g_perturbation = PerturbationMode::NO;
+    }
+    return CmdArgFlags::NONE;
+}
+
 // Keep this sorted by parameter name for binary search to work correctly.
-static std::array<CommandHandler, 157> s_commands{
+static std::array<CommandHandler, 159> s_commands{
     CommandHandler{"3d", cmd_3d},                           //
     CommandHandler{"3dmode", cmd_3d_mode},                  //
     CommandHandler{"ambient", cmd_ambient},                 //
@@ -3859,6 +3886,7 @@ static std::array<CommandHandler, 157> s_commands{
     CommandHandler{"passes", cmd_passes},                   //
     CommandHandler{"periodicity", cmd_periodicity},         //
     CommandHandler{"perspective", cmd_perspective},         //
+    CommandHandler{"perturbation", cmd_perturbation},       //
     CommandHandler{"pixelzoom", cmd_pixel_zoom},            //
     CommandHandler{"plotstyle", cmd_deprecated},            // deprecated print parameters
     CommandHandler{"polyphony", cmd_polyphony},             //
@@ -3900,6 +3928,7 @@ static std::array<CommandHandler, 157> s_commands{
     CommandHandler{"tempdir", cmd_temp_dir},                //
     CommandHandler{"textcolors", cmd_text_colors},          //
     CommandHandler{"title", cmd_deprecated},                // deprecated print parameters
+    CommandHandler{"tolerance", cmd_tolerance},             // perturbation "glitch" error tolerance
     CommandHandler{"tplus", cmd_tplus},                     //
     CommandHandler{"translate", cmd_deprecated},            // deprecated print parameters
     CommandHandler{"transparent", cmd_transparent},         //

--- a/libid/ui/cmdfiles.cpp
+++ b/libid/ui/cmdfiles.cpp
@@ -3783,6 +3783,7 @@ static CmdArgFlags cmd_perturbation(const Command &cmd)
     {
         g_perturbation = PerturbationMode::NO;
     }
+    g_use_perturbation = is_perturbation();
     return CmdArgFlags::NONE;
 }
 

--- a/libid/ui/get_toggles.cpp
+++ b/libid/ui/get_toggles.cpp
@@ -5,7 +5,9 @@
 #include "engine/calcfrac.h"
 #include "engine/id_data.h"
 #include "engine/log_map.h"
+#include "engine/perturbation.h"
 #include "fractals/fractype.h"
+#include "fractals/fractalp.h"
 #include "helpdefs.h"
 #include "io/save_timer.h"
 #include "ui/cmdfiles.h"
@@ -40,24 +42,24 @@ int get_toggles()
     char prev_save_name[ID_FILE_MAX_DIR + 1];
     FullScreenValues values[25];
     int old_sound_flag;
-    const char *calc_modes[] = {
-        "1", "2", "3", "g", "g1", "g2", "g3", "g4", "g5", "g6", "b", "s", "t", "d", "o", "p"};
-    const char *sound_modes[5] = {"off", "beep", "x", "y", "z"};
-    const char *inside_modes[] = {
-        "numb", "maxiter", "zmag", "bof60", "bof61", "epsiloncross", "startrail", "period", "atan", "fmod"};
-    const char *outside_modes[] = {"numb", "iter", "real", "imag", "mult", "summ", "atan", "fmod", "tdis"};
+    char const *calc_modes[] = {
+        "1", "2", "3", "g", "g1", "g2", "g3", "g4", "g5", "g6", "b", "s", "t", "d", "o"};
+    char const *sound_modes[5] = {"off", "beep", "x", "y", "z"};
+    char const *inside_modes[] = {
+        "numb", "maxiter", "zmag", "bof60", "bof61", "epsiloncross", "startrail", "atan", "fmod"};
+    char const *outside_modes[] = {"numb", "iter", "real", "imag", "mult", "summ", "atan", "fmod", "tdis"};
+    char const *perturbation_modes[] = {"auto", "yes", "no"};
 
     int k = -1;
 
-    choices[++k] = "Passes (1-3, g[es], b[ound], t[ess], d[iff], o[rbit], p[ert])";
+    choices[++k] = "Passes (1-3, g[es], b[ound], t[ess], d[iff], o[rbit])";
     values[k].type = 'l';
     values[k].uval.ch.vlen = 3;
     values[k].uval.ch.list_len = std::size(calc_modes);
     values[k].uval.ch.list = calc_modes;
-    values[k].uval.ch.val =
-        (g_user_std_calc_mode == '1') ? 0
-        : (g_user_std_calc_mode == '2') ? 1
-        : (g_user_std_calc_mode == '3') ? 2
+    values[k].uval.ch.val = (g_user_std_calc_mode == '1')   ? 0
+        : (g_user_std_calc_mode == '2')                     ? 1
+        : (g_user_std_calc_mode == '3')                     ? 2
         : (g_user_std_calc_mode == 'g' && g_stop_pass == 0) ? 3
         : (g_user_std_calc_mode == 'g' && g_stop_pass == 1) ? 4
         : (g_user_std_calc_mode == 'g' && g_stop_pass == 2) ? 5
@@ -65,12 +67,12 @@ int get_toggles()
         : (g_user_std_calc_mode == 'g' && g_stop_pass == 4) ? 7
         : (g_user_std_calc_mode == 'g' && g_stop_pass == 5) ? 8
         : (g_user_std_calc_mode == 'g' && g_stop_pass == 6) ? 9
-        : (g_user_std_calc_mode == 'b') ? 10
-        : (g_user_std_calc_mode == 's') ? 11
-        : (g_user_std_calc_mode == 't') ? 12
-        : (g_user_std_calc_mode == 'd') ? 13
-        : (g_user_std_calc_mode == 'o') ? 14
-        :        /* "p"erturbation */     15;
+        : (g_user_std_calc_mode == 'b')                     ? 10
+        : (g_user_std_calc_mode == 's')                     ? 11
+        : (g_user_std_calc_mode == 't')                     ? 12
+        : (g_user_std_calc_mode == 'd')                     ? 13
+        : /*(g_user_std_calc_mode == 'o') ?*/ 14;
+
     char old_user_std_calc_mode = g_user_std_calc_mode;
     int old_stop_pass = g_stop_pass;
     choices[++k] = "Maximum Iterations (2 to 2,147,483,647)";
@@ -228,6 +230,29 @@ int get_toggles()
     values[k].uval.dval = old_close_proximity;
 
     const HelpLabels old_help_mode = g_help_mode;
+    choices[++k] = "Use Perturbation (yes, no, auto - internal choice)";
+    values[k].type = 'l';
+    values[k].uval.ch.vlen = 4;
+    values[k].uval.ch.list_len = std::size(perturbation_modes);
+    values[k].uval.ch.list = perturbation_modes;
+    PerturbationMode old_perturbation = g_perturbation;
+    if (g_perturbation == PerturbationMode::AUTO)
+    {
+        values[k].uval.ch.val = 0;
+    }
+    else if (g_perturbation == PerturbationMode::YES)
+    {
+        values[k].uval.ch.val = 1;
+    }
+    else
+    {
+        values[k].uval.ch.val = 2;
+    }
+
+    choices[++k] = "Perturbation tolerance";
+    values[k].type = 'd';
+    double old_perturbation_tolerance = g_perturbation_tolerance;
+    values[k].uval.dval = old_perturbation_tolerance;
     g_help_mode = HelpLabels::HELP_X_OPTIONS;
     int i = full_screen_prompt(
         "Basic Options\n(not all combinations make sense)", k + 1, choices, values, 0, nullptr);
@@ -410,6 +435,54 @@ int get_toggles()
     ++k;
     g_close_proximity = values[k].uval.dval;
     if (g_close_proximity != old_close_proximity)
+    {
+        j++;
+    }
+
+    int tmp = values[++k].uval.ch.val;
+    if (tmp >= 0)
+    {
+        switch (tmp)
+        {
+        case 0:
+            g_perturbation = PerturbationMode::AUTO;
+            break;
+        case 1:
+            g_perturbation = PerturbationMode::YES;
+            break;
+        case 2:
+            g_perturbation = PerturbationMode::NO;
+            break;
+        }
+    }
+
+    if (bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
+    {
+        if (g_perturbation == PerturbationMode::AUTO && g_bf_math != BFMathType::NONE)
+        {
+            g_use_perturbation = true;
+        }
+        else if (g_perturbation == PerturbationMode::YES)
+        {
+            g_use_perturbation = true;
+        }
+        else
+        {
+            g_use_perturbation = false;
+        }
+    }
+    else
+    {
+        g_use_perturbation = false;
+    }
+
+    if (old_perturbation != g_perturbation)
+    {
+        j++;
+    }
+
+    g_perturbation_tolerance = values[++k].uval.dval;
+    if (old_perturbation_tolerance != g_perturbation_tolerance)
     {
         j++;
     }

--- a/libid/ui/get_toggles.cpp
+++ b/libid/ui/get_toggles.cpp
@@ -456,25 +456,7 @@ int get_toggles()
         }
     }
 
-    if (bit_set(g_cur_fractal_specific->flags, FractalFlags::PERTURB))
-    {
-        if (g_perturbation == PerturbationMode::AUTO && g_bf_math != BFMathType::NONE)
-        {
-            g_use_perturbation = true;
-        }
-        else if (g_perturbation == PerturbationMode::YES)
-        {
-            g_use_perturbation = true;
-        }
-        else
-        {
-            g_use_perturbation = false;
-        }
-    }
-    else
-    {
-        g_use_perturbation = false;
-    }
+    g_use_perturbation = is_perturbation();
 
     if (old_perturbation != g_perturbation)
     {

--- a/libid/ui/make_batch_file.cpp
+++ b/libid/ui/make_batch_file.cpp
@@ -11,6 +11,7 @@
 #include "engine/get_prec_big_float.h"
 #include "engine/id_data.h"
 #include "engine/log_map.h"
+#include "engine/perturbation.h"
 #include "engine/sticky_orbits.h"
 #include "engine/type_has_param.h"
 #include "fractals/fractalp.h"
@@ -826,6 +827,16 @@ static void write_batch_params(const char *color_inf, bool colors_only, int max_
         if (g_stop_pass != 0)
         {
             put_param(" passes=%c%c", g_user_std_calc_mode, (char)g_stop_pass + '0');
+        }
+
+        if (g_perturbation != PerturbationMode::AUTO)
+        {
+            put_param(" %s=%s", "perturbation", (g_perturbation == PerturbationMode::YES) ? "yes" : "no");
+        }
+
+        if (g_perturbation_tolerance != 1e-6)
+        {
+            put_param(" %s=%lg", "tolerance", g_perturbation_tolerance);
         }
 
         if (g_use_center_mag)

--- a/libid/ui/tab_display.cpp
+++ b/libid/ui/tab_display.cpp
@@ -355,7 +355,7 @@ top:
     {
        int ref = get_number_references();
        std::sprintf(msg, (ref == 1) ? " (%d reference)" : " (%d references)", ref);
-       driver_put_string(start_row, 45, C_GENERAL_HI, "Perturbation in use");
+       driver_put_string(start_row, 45, C_GENERAL_HI, "Perturbation");
        driver_put_string(-1, -1, C_GENERAL_HI, msg);
     }
     start_row += 1;

--- a/libid/ui/tab_display.cpp
+++ b/libid/ui/tab_display.cpp
@@ -9,6 +9,7 @@
 #include "engine/engine_timer.h"
 #include "engine/id_data.h"
 #include "engine/param_not_used.h"
+#include "engine/perturbation.h"
 #include "engine/pixel_grid.h"
 #include "engine/soi.h"
 #include "engine/type_has_param.h"
@@ -347,6 +348,15 @@ top:
         std::sprintf(msg, "(%-d decimals)", g_decimals /*getprecbf(Resolution::CURRENT)*/);
         driver_put_string(start_row, 45, C_GENERAL_HI, "Arbitrary precision ");
         driver_put_string(-1, -1, C_GENERAL_HI, msg);
+    }
+    start_row += 1;
+
+   if (g_use_perturbation)
+    {
+       int ref = get_number_references();
+       std::sprintf(msg, (ref == 1) ? " (%d reference)" : " (%d references)", ref);
+       driver_put_string(start_row, 45, C_GENERAL_HI, "Perturbation in use");
+       driver_put_string(-1, -1, C_GENERAL_HI, msg);
     }
     start_row += 1;
 


### PR DESCRIPTION
I haven't completed getting perturbation to work within standard_fractal() but there are a number of files that can be merged so we have a standard way of using Id with perturbation.

The following files can be merged so we have a standard IO and display as well as batch file operation that includes perturbation:
make_batch_file.cpp, cmdfiles.cpp, get_toggles.cpp, tab_display.cpp

Currently in this branch, perturbation only uses a single reference pixel and only renders correctly if that pixel is at the highest iteration count in the image. Getting additional reference pixels is daunting without further nodification to Standard_fractal() as the iteration count needs to be reset after adding a reference. I'm not sure how to get around this. Maybe some offline discussion will help.